### PR TITLE
feat: Added restricted countries to Geocomplete field

### DIFF
--- a/resources/js/filament-google-geocomplete.js
+++ b/resources/js/filament-google-geocomplete.js
@@ -10,6 +10,7 @@ window.filamentGoogleGeocomplete = ($wire, config) => {
             reverseGeocodeFields: {},
             latLngFields: {},
             types: [],
+            countries: [],
             isLocation: false,
             placeField: 'formatted_address',
         },
@@ -92,6 +93,10 @@ window.filamentGoogleGeocomplete = ($wire, config) => {
                 }, true);
 
                 const autocomplete = new google.maps.places.Autocomplete(geoComplete, geocompleteOptions);
+
+                autocomplete.setComponentRestrictions({
+                    country: this.config.countries,
+                })
 
                 autocomplete.addListener("place_changed", () => {
                     const place = autocomplete.getPlace();

--- a/src/Fields/Geocomplete.php
+++ b/src/Fields/Geocomplete.php
@@ -41,6 +41,8 @@ class Geocomplete extends Field implements CanBeLengthConstrained
 
     protected Closure|array $types = [];
 
+    protected Closure|array $countries = [];
+
     protected Closure|bool $debug = false;
 
     /**
@@ -271,6 +273,29 @@ class Geocomplete extends Field implements CanBeLengthConstrained
         return $types;
     }
 
+    /**
+     * And array of countries that will show up in autocomplete, see "Place Autocomplete Restricted to Multiple Countries" section of Google Places API doc:
+     *
+     * https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-multiple-countries
+     *
+     *
+     * Defaults is empty array
+     *
+     *
+     * @return $this
+     */
+    public function countries(Closure|array $countries = []): static
+    {
+        $this->countries = $countries;
+
+        return $this;
+    }
+
+    public function getCountries(): array
+    {
+        return $this->evaluate($this->countries);
+    }
+
     public function placeField(Closure|string $placeField): static
     {
         $this->placeField = $placeField;
@@ -345,6 +370,7 @@ class Geocomplete extends Field implements CanBeLengthConstrained
             'reverseGeocodeFields' => $this->getReverseGeocode(),
             'latLngFields'         => $this->getUpdateLatLngFields(),
             'types'                => $this->getTypes(),
+            'countries'            => $this->getCountries(),
             'placeField'           => $this->getPlaceField(),
             'debug'                => $this->getDebug(),
             'gmaps'                => MapsHelper::mapsUrl(),


### PR DESCRIPTION
New method:

Geocomplete::make('test')
    ->countries(['us'])

to show only selected countries in autocomplete.