### PR TITLE
Fix PHP warning with explode() in MapsHelper.php on line 40

### DIFF
--- a/src/Helpers/MapsHelper.php
+++ b/src/Helpers/MapsHelper.php
@@ -59,7 +59,7 @@ class MapsHelper
             array_filter(
                 array_merge(
                     ['places'],
-                    explode(',', config('filament-google-maps.libraries')),
+                    explode(',', (string)config('filament-google-maps.libraries')),
                     $libraries
                 )
             )


### PR DESCRIPTION
Fix PHP warning: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /app/vendor/cheesegrits/filament-google-maps/src/Helpers/MapsHelper.php on line 40