### PR TITLE
Added postal_town to %L field

### DIFF
--- a/resources/js/filament-google-geocomplete.js
+++ b/resources/js/filament-google-geocomplete.js
@@ -28,7 +28,7 @@ window.filamentGoogleGeocomplete = ($wire, config) => {
             '%a3': ["administrative_area_level_3"],
             '%a4': ["administrative_area_level_4"],
             '%a5': ["administrative_area_level_5"],
-            '%L': ["locality"],
+            '%L': ["locality", "postal_town"],
             '%D': ["sublocality"],
             '%C': ["country"],
             '%c': ["country"],

--- a/resources/js/filament-google-maps.js
+++ b/resources/js/filament-google-maps.js
@@ -59,7 +59,7 @@ window.filamentGoogleMaps = ($wire, config) => {
             '%a3': ["administrative_area_level_3"],
             '%a4': ["administrative_area_level_4"],
             '%a5': ["administrative_area_level_5"],
-            '%L': ["locality"],
+            '%L': ["locality", "postal_town"],
             '%D': ["sublocality"],
             '%C': ["country"],
             '%c': ["country"],


### PR DESCRIPTION
The field postal_town is used in the UK and Sweden, as in the Google docs here:

https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform#:~:text=In%20the%20UK%20and%20in%20Sweden%2C%20the%20component%20to%20display%20the%20city%20is%20postal_town.