### PR TITLE
Make commands compatible with Filament 3.0.9+

### DIFF
--- a/src/Commands/Concerns/CanValidateInput.php
+++ b/src/Commands/Concerns/CanValidateInput.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Cheesegrits\FilamentGoogleMaps\Commands\Concerns;
+
+use Closure;
+use Illuminate\Support\Facades\Validator;
+
+trait CanValidateInput
+{
+    protected function askRequired(string $question, string $field, ?string $default = null): string
+    {
+        return $this->validateInput(fn () => $this->ask($question, $default), $field, ['required']);
+    }
+
+    /**
+     * @param  array<array-key>  $rules
+     */
+    protected function validateInput(Closure $askUsing, string $field, array $rules, ?Closure $onError = null): string
+    {
+        $input = $askUsing();
+
+        $validator = Validator::make(
+            [$field => $input],
+            [$field => $rules],
+        );
+
+        if ($validator->fails()) {
+            $this->components->error($validator->errors()->first());
+
+            if ($onError) {
+                $onError($validator);
+            }
+
+            $input = $this->validateInput($askUsing, $field, $rules);
+        }
+
+        return $input;
+    }
+}

--- a/src/Commands/Geocode.php
+++ b/src/Commands/Geocode.php
@@ -3,12 +3,12 @@
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
 use Cheesegrits\FilamentGoogleMaps\Helpers\Geocoder;
-use Filament\Support\Commands\Concerns\CanValidateInput;
+//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 
 class Geocode extends Command
 {
-    use CanValidateInput;
+//    use CanValidateInput;
 
     protected $signature = 'filament-google-maps:geocode {--address=} {--A|array} {--C|command} {--G|args}';
 

--- a/src/Commands/Geocode.php
+++ b/src/Commands/Geocode.php
@@ -2,13 +2,13 @@
 
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
+use Cheesegrits\FilamentGoogleMaps\Commands\Concerns\CanValidateInput;
 use Cheesegrits\FilamentGoogleMaps\Helpers\Geocoder;
-//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 
 class Geocode extends Command
 {
-//    use CanValidateInput;
+    use CanValidateInput;
 
     protected $signature = 'filament-google-maps:geocode {--address=} {--A|array} {--C|command} {--G|args}';
 

--- a/src/Commands/GeocodeTable.php
+++ b/src/Commands/GeocodeTable.php
@@ -2,15 +2,15 @@
 
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
+use Cheesegrits\FilamentGoogleMaps\Commands\Concerns\CanValidateInput;
 use Cheesegrits\FilamentGoogleMaps\Helpers\Geocoder;
-//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Throwable;
 
 class GeocodeTable extends Command
 {
-//    use CanValidateInput;
+    use CanValidateInput;
 
     protected $signature = 'filament-google-maps:geocode-table {model?} {--lat=} {--lng=} {--fields=} {--processed=} {--rate-limit=} {--verbose?}}';
 

--- a/src/Commands/GeocodeTable.php
+++ b/src/Commands/GeocodeTable.php
@@ -3,14 +3,14 @@
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
 use Cheesegrits\FilamentGoogleMaps\Helpers\Geocoder;
-use Filament\Support\Commands\Concerns\CanValidateInput;
+//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Throwable;
 
 class GeocodeTable extends Command
 {
-    use CanValidateInput;
+//    use CanValidateInput;
 
     protected $signature = 'filament-google-maps:geocode-table {model?} {--lat=} {--lng=} {--fields=} {--processed=} {--rate-limit=} {--verbose?}}';
 

--- a/src/Commands/MakeWidgetCommand.php
+++ b/src/Commands/MakeWidgetCommand.php
@@ -3,14 +3,14 @@
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
-use Filament\Support\Commands\Concerns\CanValidateInput;
+//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 
 class MakeWidgetCommand extends Command
 {
     use CanManipulateFiles;
-    use CanValidateInput;
+//    use CanValidateInput;
 
     private $widgetClasses = ['MapWidget', 'MapTableWidget'];
 

--- a/src/Commands/MakeWidgetCommand.php
+++ b/src/Commands/MakeWidgetCommand.php
@@ -2,15 +2,15 @@
 
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
+use Cheesegrits\FilamentGoogleMaps\Commands\Concerns\CanValidateInput;
 use Filament\Support\Commands\Concerns\CanManipulateFiles;
-//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 
 class MakeWidgetCommand extends Command
 {
     use CanManipulateFiles;
-//    use CanValidateInput;
+    use CanValidateInput;
 
     private $widgetClasses = ['MapWidget', 'MapTableWidget'];
 

--- a/src/Commands/ModelCode.php
+++ b/src/Commands/ModelCode.php
@@ -2,27 +2,25 @@
 
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
-use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\text;
 
 class ModelCode extends Command
 {
-    use CanValidateInput;
-
     protected $signature = 'filament-google-maps:model-code {model?} {--lat=} {--lng=} {--location=} {--T|terse}';
 
     protected $description = 'Produce computed attribute code for a model to work with Filament Google Maps';
 
     public function handle()
     {
-        $asking = false;
-
         $modelName = $this->argument('model');
 
         if (! $modelName) {
-            $asking    = true;
-            $modelName = $this->askRequired('Model (e.g. `Location` or `Maps/Dealership`)', 'model');
+            $modelName = text(
+                label: 'Model (e.g. `Location` or `Maps/Dealership`)', required: true
+            );
         }
 
         $modelName = (string) Str::of($modelName)
@@ -46,18 +44,17 @@ class ModelCode extends Command
         }
 
         $latField = $this->option('lat')
-            ?? $this->askRequired('Latitude table field name (e.g. `lat`)', 'lat');
+            ?? text(label: 'Longitude table field name (e.g. `lat`)', default: 'lat', required: true);
 
         $lngField = $this->option('lng')
-            ?? $this->askRequired('Longitude table field name (e.g. `lat`)', 'lng');
+            ?? text(label: 'Longitude table field name (e.g. `lng`)', default: 'lng', required: true);
 
         $locationField = $this->option('location')
-            ?? $this->askRequired('Computed location attribute name (e.g. `location`)', 'location');
+            ?? text(label: 'Computed location attribute name (e.g. `location`)', default: 'location', required: true);
 
-        if ($asking) {
-            $comments = $this->confirm('Include comments in the code?', true);
-        } else {
-            $comments = ! $this->option('terse');
+        $comments = confirm('Include comments in the code?', default: true, yes: 'Include them', no: 'Do not include them');
+        if(! $comments) {
+            $this->option('terse');
         }
 
         $guardedStr = '';

--- a/src/Commands/ReverseGeocode.php
+++ b/src/Commands/ReverseGeocode.php
@@ -2,13 +2,13 @@
 
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
+use Cheesegrits\FilamentGoogleMaps\Commands\Concerns\CanValidateInput;
 use Cheesegrits\FilamentGoogleMaps\Helpers\Geocoder;
-//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 
 class ReverseGeocode extends Command
 {
-//    use CanValidateInput;
+    use CanValidateInput;
 
     protected $signature = 'filament-google-maps:reverse-geocode {--lat=} {--lng=} {--C|components}';
 

--- a/src/Commands/ReverseGeocode.php
+++ b/src/Commands/ReverseGeocode.php
@@ -3,12 +3,12 @@
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
 use Cheesegrits\FilamentGoogleMaps\Helpers\Geocoder;
-use Filament\Support\Commands\Concerns\CanValidateInput;
+//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 
 class ReverseGeocode extends Command
 {
-    use CanValidateInput;
+//    use CanValidateInput;
 
     protected $signature = 'filament-google-maps:reverse-geocode {--lat=} {--lng=} {--C|components}';
 

--- a/src/Commands/ReverseGeocodeTable.php
+++ b/src/Commands/ReverseGeocodeTable.php
@@ -3,14 +3,14 @@
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
 use Cheesegrits\FilamentGoogleMaps\Helpers\Geocoder;
-use Filament\Support\Commands\Concerns\CanValidateInput;
+//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Throwable;
 
 class ReverseGeocodeTable extends Command
 {
-    use CanValidateInput;
+//    use CanValidateInput;
 
     protected $signature = 'filament-google-maps:reverse-geocode-table {model?} {--lat=} {--lng=} {--fields=*} {--processed=} {--rate-limit=} {--verbose?}}';
 

--- a/src/Commands/ReverseGeocodeTable.php
+++ b/src/Commands/ReverseGeocodeTable.php
@@ -2,15 +2,15 @@
 
 namespace Cheesegrits\FilamentGoogleMaps\Commands;
 
+use Cheesegrits\FilamentGoogleMaps\Commands\Concerns\CanValidateInput;
 use Cheesegrits\FilamentGoogleMaps\Helpers\Geocoder;
-//use Filament\Support\Commands\Concerns\CanValidateInput;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Throwable;
 
 class ReverseGeocodeTable extends Command
 {
-//    use CanValidateInput;
+    use CanValidateInput;
 
     protected $signature = 'filament-google-maps:reverse-geocode-table {model?} {--lat=} {--lng=} {--fields=*} {--processed=} {--rate-limit=} {--verbose?}}';
 


### PR DESCRIPTION
The `CanValidateInput` class was deleted in Filament in 3.0.9. I copied that into this project locally to use for all the commands.

I also drafted updating to use Laravel Prompts for the ModelCode command. That's probably the long term solution, but the rest of the commands no longer break everything.