### PR TITLE
Fix "Trying to access array offset on value of type null"

### DIFF
--- a/src/Fields/Geocomplete.php
+++ b/src/Fields/Geocomplete.php
@@ -450,6 +450,6 @@ class Geocomplete extends Field implements Contracts\CanBeLengthConstrained, Con
     {
         $state = $this->getState();
 
-        return $state['formatted_address'];
+        return $state['formatted_address'] ?? '';
     }
 }


### PR DESCRIPTION
After a recent upgrade, I'm getting this error when just loading a page with a Geocomplete on it:

ErrorException: Trying to access array offset on value of type null in /Users/kevinmckee/Code/journey/vendor/cheesegrits/filament-google-maps/src/Fields/Geocomplete.php:453

This small change removes the error.