### PR TITLE
properly check whether paginating by all

### DIFF
--- a/src/Widgets/MapTableWidget.php
+++ b/src/Widgets/MapTableWidget.php
@@ -44,7 +44,7 @@ class MapTableWidget extends MapWidget implements Tables\Contracts\HasTable
 
     protected function paginateTableQuery(Builder $query): Paginator
     {
-        return $query->simplePaginate($this->getTableRecordsPerPage() == -1 ? $query->count() : $this->getTableRecordsPerPage());
+        return $query->simplePaginate($this->getTableRecordsPerPage() == 'all' ? $query->count() : $this->getTableRecordsPerPage());
     }
 
     protected function getRecords()


### PR DESCRIPTION
According to the Filament code, the way to know if perPage is set to all is the value 'all' instead of -1
https://github.com/filamentphp/filament/blob/0a2b41b73293d81d8031f0e25666a18ed9145778/packages/tables/src/Concerns/CanPaginateRecords.php#L33

This `paginateTableQuery()` function can be probably be removed completely and but I wasn't sure why it was overriding the base function in the first place. 