### PR TITLE
Added subpremise, route support in list of available symbols

### DIFF
--- a/resources/js/filament-google-maps.js
+++ b/resources/js/filament-google-maps.js
@@ -98,6 +98,8 @@ export default function filamentGoogleMapsField({
       "%c": ["country"],
       "%p": ["premise"],
       "%P": ["premise"],
+      "%sp": ["subpremise", "route"],
+      "%SP": ["subpremise", "route"],
     },
     drawingManager: null,
     overlays: [],


### PR DESCRIPTION
Added sub premise in the symbols list, can be useful if someone wants to store Address line 2