### PR TITLE
Fix nullable collection on Geocoder::reverse

### DIFF
--- a/src/Helpers/Geocoder.php
+++ b/src/Helpers/Geocoder.php
@@ -126,7 +126,7 @@ class Geocoder
 
     public function reverse(array|string $lat, ?string $lng = null): string
     {
-        $result = $this->reverseQuery(MapsHelper::getLatLng($lat, $lng))->first();
+        $result = $this->reverseQuery(MapsHelper::getLatLng($lat, $lng))?->first();
 
         if ($result) {
             return $result->getFormattedAddress();


### PR DESCRIPTION
There is a problem in my case I think `reverseQuery` does not return a correct Collection and it causes the problem below; 

Update: I can confirm that if the Google Maps API Key is limited because of the issued Credit Card has expired, you get an empty collection. 

<img width="466" alt="image" src="https://github.com/cheesegrits/filament-google-maps/assets/4797768/98c184eb-fac4-4b7b-8968-26bc47002feb">
