### PR TITLE
Update maps column view to allow the use of placeholders

### DIFF
--- a/resources/views/columns/filament-google-maps-column.blade.php
+++ b/resources/views/columns/filament-google-maps-column.blade.php
@@ -10,8 +10,8 @@
         $alignment = $getAlignment();
 
         if (! $alignment instanceof Alignment) {
-        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
-    }
+            $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+        }
     @endphp
 
     <div

--- a/resources/views/columns/filament-google-maps-column.blade.php
+++ b/resources/views/columns/filament-google-maps-column.blade.php
@@ -3,11 +3,28 @@
     'px-4 py-3' => ! $isInline(),
 ]) }}>
     @php
+        use Filament\Support\Enums\Alignment;
+
         $height = $getHeight();
         $width = $getWidth();
+        $alignment = $getAlignment();
+
+        if (! $alignment instanceof Alignment) {
+        $alignment = filled($alignment) ? (Alignment::tryFrom($alignment) ?? $alignment) : null;
+    }
     @endphp
 
     <div
+        @class([
+            'flex items-center',
+            match ($alignment) {
+                Alignment::Start, Alignment::Left => 'text-start justify-start',
+                Alignment::Center => 'text-center justify-center',
+                Alignment::End, Alignment::Right => 'text-end justify-end',
+                Alignment::Between, Alignment::Justify => 'text-justify justify-between',
+                default => $alignment,
+            },
+        ])
         style="
             {!! $height !== null ? "height: {$height}px;" : null !!}
             {!! $width !== null ? "width: {$width}px;" : null !!}
@@ -22,6 +39,10 @@
                 "
                 {{ $getExtraImgAttributeBag() }}
             >
-       @endif
+        @elseif (($placeholder = $getPlaceholder()) !== null)
+            <x-filament-tables::columns.placeholder>
+                {{ $placeholder }}
+            </x-filament-tables::columns.placeholder>
+        @endif
     </div>
 </div>


### PR DESCRIPTION
```php
FilamentGoogleMaps\Columns\MapColumn::make('coordinates')
    ->label('Map')
    ->type('hybrid')
    ->alignCenter()
    ->zoom(14)
    ->height(100)
    ->width(150)
    ->placeholder(fn (): HtmlString => new HtmlString('&mdash;')),
```

Preview:

![CleanShot 2024-08-27 at 19 29 11](https://github.com/user-attachments/assets/bcce5de4-502a-49cc-b0d7-3ff799455664)
