### PR TITLE
Add async and defer to Google Maps API script

### DIFF
--- a/src/Helpers/MapsHelper.php
+++ b/src/Helpers/MapsHelper.php
@@ -71,6 +71,8 @@ class MapsHelper
 
         $gmaps = (config('filament-google-maps.force-https') ? 'https' : Request::getScheme() ?? 'https') . '://maps.googleapis.com/maps/api/js'
             . '?key=' . self::mapsKey($server)
+            . '&loading=async'
+            . '&defer'
             . '&libraries=' . $libraries
             . '&v=weekly';
 


### PR DESCRIPTION
This change makes the Google Maps API script load asynchronously and defer execution until page parsing is complete. These modifications aim to improve page load performance and usability.