### PR TITLE
fix: afterStateUpdated closure not firing

### DIFF
--- a/resources/views/fields/filament-google-maps.blade.php
+++ b/resources/views/fields/filament-google-maps.blade.php
@@ -8,7 +8,7 @@
         ax-load
         ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-google-maps-field', 'cheesegrits/filament-google-maps') }}"
         x-data="filamentGoogleMapsField({
-                    state: $wire.entangle('{{ $getStatePath() }}'),
+                    state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$getStatePath()}')") }},
                     setStateUsing: (path, state) => {
                         return $wire.set(path, state)
                     },


### PR DESCRIPTION
`->live()` on the Map form field didn't do anything, because the live flag wasn't set accordingly in the `$wire.entangle` call in the view.

fixes cheesegrits/filament-google-maps#67