### PR TITLE
Fix/filament v4 bug when component is an action

### DIFF
--- a/src/Concerns/InteractsWithMaps.php
+++ b/src/Concerns/InteractsWithMaps.php
@@ -28,7 +28,11 @@ trait InteractsWithMaps
                 return true;
             }
 
-            foreach ($component->getChildComponentContainers() as $childComponentContainer) {
+            if(! $component instanceof Component){
+                return false;
+            }
+
+            foreach ($component->getChildSchemas() as $childComponentContainer) {
                 if ($childComponentContainer->isHidden()) {
                     continue;
                 }

--- a/src/Concerns/InteractsWithMaps.php
+++ b/src/Concerns/InteractsWithMaps.php
@@ -62,7 +62,10 @@ trait InteractsWithMaps
                 return true;
             }
 
-            foreach ($component->getChildComponentContainers() as $childComponentContainer) {
+            if(! $component instanceof Component){
+                return false;
+            }
+
             foreach ($component->getChildSchemas() as $childComponentContainer) {
                 if ($childComponentContainer->isHidden()) {
                     continue;

--- a/src/Concerns/InteractsWithMaps.php
+++ b/src/Concerns/InteractsWithMaps.php
@@ -4,6 +4,7 @@ namespace Cheesegrits\FilamentGoogleMaps\Concerns;
 
 use Cheesegrits\FilamentGoogleMaps\Fields\Geocomplete;
 use Cheesegrits\FilamentGoogleMaps\Fields\Map;
+use Filament\Schemas\Components\Component;
 
 trait InteractsWithMaps
 {
@@ -62,6 +63,7 @@ trait InteractsWithMaps
             }
 
             foreach ($component->getChildComponentContainers() as $childComponentContainer) {
+            foreach ($component->getChildSchemas() as $childComponentContainer) {
                 if ($childComponentContainer->isHidden()) {
                     continue;
                 }


### PR DESCRIPTION
When `$component` is not an instance of `Filament\Schemas\Components\Component`, which is the case for Action for example, an error is thrown.

This PR prevent that, as well as replacing deprecated `getChildComponentContainers` method with `getChildSchemas` one